### PR TITLE
Develop

### DIFF
--- a/dnsconfig.js
+++ b/dnsconfig.js
@@ -31,6 +31,7 @@ D("noclocks.dev", REG_NONE
 	, CNAME("gmail", "ghs.googlehosted.com.")
 	, CNAME("ggroups", "ghs.googlehosted.com.")
 	, CNAME("gsites", "ghs.googlehosted.com.")
+	, CNAME("bastien", "ghs.googlehosted.com.")
 	, MX("@", 1, "smtp.google.com.")
 	, TXT("@", "stripe-verification=89f4a41b52e121c2857c7989fa0edea55106bec6c43be66692ce13c3fd826707")
 	, TXT("google._domainkey", "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnxb49YRvvMIjYWCEkGS8uRyi2jFfJYwuA4/b59aMAraFcJjeB+Xx6MvhAVpCe2/Zh/QGPtaAFbsluKJPTzW4qnddz85WVurrdIhxgVeyr417kPlYu1t8GbGQ1MQ53J4cPxs3x7beCLNbfXOF16o3wektAKb9Ap9oEioFysB9ingRLju+xGzpCii3vSFeDbYBYnheSzgPpo7fw5eQbnEN8iHu1XUQCunSxC0pOD8dWdM6pgXZ2UR3zehE+jjwtlNgz216+wUVn5E1CELk4fPqbMM0lhXFBUyAceH0sx4Zbo09ix74cOU34OlNxvdCUgQYNYCEBe7psW9hesbSiev8twIDAQAB")


### PR DESCRIPTION
- Temporary subdomain mapping for [bastien.noclocks.dev](https://bastien.noclocks.dev)